### PR TITLE
Remove strict_max_version

### DIFF
--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -2,8 +2,7 @@
   "applications": {
     "gecko": {
       "id": "examplewebextension@mozilla.org",
-        "strict_min_version": "48.0",
-        "strict_max_version": "100.*"
+        "strict_min_version": "48.0"
     }
   },
   "background": {


### PR DESCRIPTION
strict_max_version is no(?) longer mandatory so it's safe to remove it.